### PR TITLE
Add explicit workflow permissions

### DIFF
--- a/.github/workflows/updateSDKQueries.yml
+++ b/.github/workflows/updateSDKQueries.yml
@@ -2,6 +2,9 @@ on:
   workflow_dispatch:
 
 name: Update SDK queries
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   updateQueries:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fragment-dev/fragment-python/security/code-scanning/1](https://github.com/fragment-dev/fragment-python/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow to explicitly define the permissions required for the workflow. Since the workflow involves checking out repositories, creating pull requests, and running commands, the minimal permissions required are `contents: read` and `pull-requests: write`. This ensures that the workflow has only the necessary access to perform its tasks.

The `permissions` block should be added after the `name` key in the workflow file. No additional imports or dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
